### PR TITLE
Add substitution for built-in LED

### DIFF
--- a/esphome-gas-meter.yaml
+++ b/esphome-gas-meter.yaml
@@ -1,5 +1,6 @@
 ---
 substitutions:
+  gpio_led: GPIO2
   # For gas one of: CCF, ft³, m³
   volume_unit: 'ft³'
   # The most common value in US seems to be 0.125 ft³
@@ -20,5 +21,5 @@ switch:
   - platform: gpio
     id: led
     pin:
-      number: GPIO2
+      number: ${gpio_led}
       inverted: true

--- a/esphome-two-meters.yaml
+++ b/esphome-two-meters.yaml
@@ -14,6 +14,8 @@ substitutions:
   prefix2_name: 'Gas '
   prefix2_id: 'gas_'
 
+  gpio_led: GPIO2
+
   i2c1_sda: GPIO4
   i2c1_scl: GPIO5
   i2c2_sda: GPIO12
@@ -51,5 +53,5 @@ switch:
   - platform: gpio
     id: led
     pin:
-      number: GPIO2
+      number: ${gpio_led}
       inverted: true

--- a/esphome-water-meter.yaml
+++ b/esphome-water-meter.yaml
@@ -1,5 +1,6 @@
 ---
 substitutions:
+  gpio_led: GPIO2
   # For water one of: CCF, ft³, gal, L, m³
   volume_unit: 'gal'
 
@@ -15,5 +16,5 @@ switch:
   - platform: gpio
     id: led
     pin:
-      number: GPIO2
+      number: ${gpio_led}
       inverted: true


### PR DESCRIPTION
Fixes: #30

___

Just want to say thanks for all of your work on this project. I initially went the AI-on-the-edge route, assuming it would be easier, but was sufficiently beleaguered by misidentifications that I circled back to your project here and gave it a shot. Only a couple of days in, but already convinced this is The Answer™️ and deserves a much stronger recommendation in the HA docs.

I was able to get this running on an ESP32-C6 (specifically, the [Seeed Studio XIAO ESP32C6](https://www.seeedstudio.com/Seeed-Studio-XIAO-ESP32C6-p-5884.html)) with just a few minor modifications. The main one being remapping the built-in LED from the project's default `GPIO2` to `GPIO15` for the XIAO ESP32-C6.