### PR TITLE
feat: add MLX90393 magnetometer support, some debugging helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # esphome-magnetometer-water-gas-meter [![Made for ESPHome](https://img.shields.io/badge/Made_for-ESPHome-black?logo=esphome)](https://esphome.io)
 
-This [ESPHome](https://esphome.io) package allows reading your water meter or gas meter using the QMC5883L or QMC5883P or HMC5883L or MMC5603, a triple-axis magnetometer.
+This [ESPHome](https://esphome.io) package allows reading your water meter or gas meter using the QMC5883L or QMC5883P or HMC5883L or MMC5603 or MLX90393, a triple-axis magnetometer.
 
 TLDR; Add this to your ESPHome device configuration:
 
@@ -28,6 +28,8 @@ packages:
     # files: [esphome-water-meter.yaml, hmc5883l.yaml]
     # Or if you are using MMC5603 instead of QMC5883L:
     # files: [esphome-water-meter.yaml, mmc5603.yaml]
+    # Or if you are using MLX90393 instead of QMC5883L:
+    # files: [esphome-water-meter.yaml, mlx90393.yaml]
     refresh: 0s
 ```
 

--- a/esphome-magnetometer.yaml
+++ b/esphome-magnetometer.yaml
@@ -14,6 +14,8 @@ substitutions:
 
   i2c_scl: GPIO5  # D1
   i2c_sda: GPIO4  # D2
+  i2c_scan: false
+  i2c_address: 0x0D
 
   # Set these only if you have connected two QMC5883L to one device, see esphome-two-meters.yaml
   prefix_name: ''
@@ -361,7 +363,7 @@ i2c:
     scl: ${i2c_scl}
     sda: ${i2c_sda}
     frequency: 50kHz
-    scan: false
+    scan: ${i2c_scan}
 
 sensor:
   # Holds the magnetic field strength value of x, y, or z depending on the axis template select.
@@ -445,7 +447,7 @@ sensor:
   - platform: qmc5883l
     id: ${prefix_id}qmc5883l_id
     i2c_id: ${prefix_id}i2c_bus
-    address: 0x0D
+    address: ${i2c_address}
     field_strength_x:
       id: ${prefix_id}qmc5883l_axis_x
       name: ${prefix_name}Magnetic Field Strength X

--- a/esphome-magnetometer.yaml
+++ b/esphome-magnetometer.yaml
@@ -276,9 +276,10 @@ text_sensor:
 
 button:
   - platform: template
-    name: "Reset Meter Values"
-    id: reset_gas_meter_total
-    entity_category: diagnostic
+    name: "${prefix_name}Reset Meter Values"
+    id: ${prefix_id}reset_meter_values
+    disabled_by_default: true
+    entity_category: config
     icon: "mdi:restart"
     on_press:
       then:

--- a/esphome-magnetometer.yaml
+++ b/esphome-magnetometer.yaml
@@ -276,6 +276,16 @@ text_sensor:
 
 button:
   - platform: template
+    name: "Reset Meter Values"
+    id: reset_gas_meter_total
+    entity_category: diagnostic
+    icon: "mdi:restart"
+    on_press:
+      then:
+        - lambda: |-
+            id(${prefix_id}half_rotations_total) = 0;
+            id(${prefix_id}sensor_total).publish_state(0);
+  - platform: template
     id: ${prefix_id}calibrate_button
     name: ${prefix_name}Calibrate axis
     entity_category: config

--- a/mlx90393.yaml
+++ b/mlx90393.yaml
@@ -1,0 +1,63 @@
+---
+logger:
+  logs:
+    mlx90393: INFO
+number:
+  - id: !remove ${prefix_id}temperature_offset
+sensor:
+  - id: !extend ${prefix_id}qmc5883l_id
+    platform: mlx90393
+    oversampling: 1
+    filter: 5
+    temperature: !remove ${prefix_id}qmc5883l_temperature
+    field_strength_z: !remove ${prefix_id}qmc5883l_axis_z
+    field_strength_y: !remove ${prefix_id}qmc5883l_axis_y
+    field_strength_x: !remove ${prefix_id}qmc5883l_axis_x
+    x_axis:
+      id: ${prefix_id}qmc5883l_axis_x
+      name: ${prefix_name}Magnetic Field Strength X
+      internal: ${hide_magnetic_field_strength_sensors}
+      entity_category: diagnostic
+      resolution: DIV_8
+      on_raw_value:
+        then:
+          - lambda: |-
+              if (id(${prefix_id}axis).current_option() == "x") id(${prefix_id}axis_value).publish_state(x);
+              if (id(${prefix_id}calibrating)) {
+                id(${prefix_id}calibrating_axis_x_min) = min(id(${prefix_id}calibrating_axis_x_min), x);
+                id(${prefix_id}calibrating_axis_x_max) = max(id(${prefix_id}calibrating_axis_x_max), x);
+              }
+      filters:
+        - delta: ${magnetic_field_update_delta}
+    y_axis:
+      id: ${prefix_id}qmc5883l_axis_y
+      name: ${prefix_name}Magnetic Field Strength Y
+      internal: ${hide_magnetic_field_strength_sensors}
+      entity_category: diagnostic
+      resolution: DIV_8
+      on_raw_value:
+        then:
+          - lambda: |-
+              if (id(${prefix_id}axis).current_option() == "y") id(${prefix_id}axis_value).publish_state(x);
+              if (id(${prefix_id}calibrating)) {
+                id(${prefix_id}calibrating_axis_y_min) = min(id(${prefix_id}calibrating_axis_y_min), x);
+                id(${prefix_id}calibrating_axis_y_max) = max(id(${prefix_id}calibrating_axis_y_max), x);
+              }
+      filters:
+        - delta: ${magnetic_field_update_delta}
+    z_axis:
+      id: ${prefix_id}qmc5883l_axis_z
+      name: ${prefix_name}Magnetic Field Strength Z
+      internal: ${hide_magnetic_field_strength_sensors}
+      entity_category: diagnostic
+      resolution: DIV_8
+      on_raw_value:
+        then:
+          - lambda: |-
+              if (id(${prefix_id}axis).current_option() == "z") id(${prefix_id}axis_value).publish_state(x);
+              if (id(${prefix_id}calibrating)) {
+                id(${prefix_id}calibrating_axis_z_min) = min(id(${prefix_id}calibrating_axis_z_min), x);
+                id(${prefix_id}calibrating_axis_z_max) = max(id(${prefix_id}calibrating_axis_z_max), x);
+              }
+      filters:
+        - delta: ${magnetic_field_update_delta}


### PR DESCRIPTION
Hi, thanks a lot for the great project! Since I had connectivity issues with an QMC5883L, I wanted to try out another sensor, I opted for the MLX90393 since it's released by Adafruit and supported by ESPHome. The YAML is quite large as the sensor reports its mT values on `x_axis` etc instead of `field_strength_x`. Added some tweaking to the filter and resolution so it works well on my old gas meter.

Also, I've added a few helpers:

- A button entity to reset meter values
- Making `i2c: address` configurable (as MLX90393 has multiple possible I2C addresses configurable via jumper
- `i2c_scan` boolean to enable scanning, was helpful for finding the right address.

Let me know what you think. I can also just create a branch for only the MLX sensor if you don't want to carry over the debug stuff. 

Cheers!