### PR TITLE
Gas meter improvements: interval-based flow, calibration defaults, drive rate docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,14 @@ Alternatively:
 5. Set `hide_half_rotations_total_sensor: 'true'`.
 
 For water meters this defaults to `0.01008156 gal` which is for my 3/4" Badge Meter Model 35.
-For gas meters this defaults to `0.125 ft³` which seems to be the most common in US.
+For gas meters this defaults to `0.125 ft³` which is common when the magnet couples to the
+bellows/diaphragm drive. However, on many AMR-equipped meters (e.g. Aclara STAR modules) the
+magnet is mounted on the index drive shaft instead, where one rotation equals the meter's
+drive rate — often 1 or 2 ft³. You can identify the drive rate from the small proving/test
+dials on the index: "2 FT" and "1/2 FT" dials indicate a 2-foot drive (2.0 ft³ per rotation),
+while "1 FT" and "1/4 FT" dials indicate a 1-foot drive (1.0 ft³ per rotation). To verify,
+time several revolutions of the smallest proving dial during steady flow and compare against
+the interval between half-rotation counts.
 If you have modified the `volume_unit` you have to manually convert this value.
 
 ### Setting Total Volume

--- a/esphome-gas-meter.yaml
+++ b/esphome-gas-meter.yaml
@@ -5,11 +5,19 @@ substitutions:
   # For better accuracy avoid using large units like CCF.
   # You can always change the unit later in Home Assistant.
   volume_unit: 'ft³'
-  # The most common value in US seems to be 0.125 ft³
-  # If you modify the volume_unit, modify this too,
-  # just search on Google: 0.125 ft³ to CCF (or whatever unit you selected)
+  # This depends on where the magnet sits in your meter, which varies a lot:
+  #  - Bellows/diaphragm coupling: often 0.125 ft³, common on meters with no AMR.
+  #  - Index drive shaft: equals the meter's drive rating. US AMR-equipped meters
+  #    frequently put the magnet here. A "2-foot drive" meter (e.g. Sensus R-275)
+  #    gives 2.0 ft³ per rotation — 16x the old default.
+  # Measure it: note "Half rotations total", time a known volume from the meter's
+  # test dial, then divide. Do not assume.
   volume_per_half_rotation_initial_value: '0.125'
   calibration_minimal_axis_range_initial_value: '15'
+  # Gas meters can take minutes per rotation at low flow. Calibration must span
+  # at least one full rotation or the captured min/max will be a fragment of the
+  # real swing, producing a magnet span that is far too small.
+  calibration_seconds_initial_value: '120'
   flow_update_interval_seconds: '30'
   magnetic_field_update_delta: '1'
 

--- a/esphome-magnetometer.yaml
+++ b/esphome-magnetometer.yaml
@@ -54,6 +54,9 @@ substitutions:
   # the opposite tracker is dragged along to maintain the maximum allowed size.
   # 1.1 = Max allowed window is 120% of calibrated size.
   max_span_multiplier: '1.2'
+  # Flow is reported as zero if no half rotation has been seen for this long.
+  # Should comfortably exceed the slowest rotation you expect at minimum flow.
+  flow_zero_timeout_seconds: '600'
 
 esphome:
   min_version: "2026.1.0"
@@ -88,6 +91,14 @@ globals:
     initial_value: '0'
   - id: ${prefix_id}half_rotations_flow
     type: long
+    restore_value: false
+    initial_value: '0'
+  - id: ${prefix_id}last_half_rotation_ms
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+  - id: ${prefix_id}last_interval_ms
+    type: uint32_t
     restore_value: false
     initial_value: '0'
   - id: ${prefix_id}axis_value_high
@@ -431,6 +442,13 @@ sensor:
                 id(${prefix_id}axis_value_high) = true;
                 id(${prefix_id}half_rotations_total) += 1;
                 id(${prefix_id}half_rotations_flow) += 1;
+                {
+                  uint32_t now_ms = millis();
+                  if (id(${prefix_id}last_half_rotation_ms) != 0) {
+                    id(${prefix_id}last_interval_ms) = now_ms - id(${prefix_id}last_half_rotation_ms);
+                  }
+                  id(${prefix_id}last_half_rotation_ms) = now_ms;
+                }
                 id(led).turn_on();
               } else if (x < (midpoint - hyst) && id(${prefix_id}axis_value_high)) {
                 id(${prefix_id}axis_value_high) = false;
@@ -443,6 +461,13 @@ sensor:
               id(${prefix_id}axis_value_high) = true;
               id(${prefix_id}half_rotations_total) += 1;
               id(${prefix_id}half_rotations_flow) += 1;
+              {
+                uint32_t now_ms = millis();
+                if (id(${prefix_id}last_half_rotation_ms) != 0) {
+                  id(${prefix_id}last_interval_ms) = now_ms - id(${prefix_id}last_half_rotation_ms);
+                }
+                id(${prefix_id}last_half_rotation_ms) = now_ms;
+              }
               id(led).turn_on();
             } else if (x < id(${prefix_id}threshold_lower).state && id(${prefix_id}axis_value_high)) {
               id(${prefix_id}axis_value_high) = false;
@@ -573,9 +598,16 @@ sensor:
     device_class: volume_flow_rate
     icon: mdi:speedometer
     lambda: |-
-      float flow = id(${prefix_id}half_rotations_flow) * id(${prefix_id}volume_per_half_rotation).state * 60.0 / ${flow_update_interval_seconds};
+      // Interval-based flow: rate derived from time between half rotations.
+      // Avoids the quantization of counting within a fixed window, which is
+      // coarse on slow meters (one count per window = one discrete flow value).
       id(${prefix_id}half_rotations_flow) = 0;
-      return flow;
+      if (id(${prefix_id}last_interval_ms) == 0) return 0.0;
+      uint32_t elapsed = millis() - id(${prefix_id}last_half_rotation_ms);
+      // Use whichever is longer so flow decays smoothly once rotations stop
+      uint32_t period = std::max(id(${prefix_id}last_interval_ms), elapsed);
+      if (period > ${flow_zero_timeout_seconds} * 1000UL) return 0.0;
+      return id(${prefix_id}volume_per_half_rotation).state * 60000.0 / period;
     update_interval: ${flow_update_interval_seconds}s
     accuracy_decimals: 2
     state_class: measurement

--- a/esphome-magnetometer.yaml
+++ b/esphome-magnetometer.yaml
@@ -57,6 +57,14 @@ substitutions:
   # Flow is reported as zero if no half rotation has been seen for this long.
   # Should comfortably exceed the slowest rotation you expect at minimum flow.
   flow_zero_timeout_seconds: '600'
+  # Calibration must span at least one full magnet rotation to capture the true
+  # min and max. Water meters rotate fast; gas meters can take minutes per
+  # rotation, so the gas package raises this.
+  calibration_seconds_initial_value: '5'
+  # Delta filter on the Half rotations total sensor. The filter passes only when
+  # the change exceeds this, so the default of 1 makes the counter appear to
+  # advance in steps of 2. Set to 0 to see every increment while calibrating.
+  half_rotations_update_delta: '1'
 
 esphome:
   min_version: "2026.1.0"
@@ -240,7 +248,7 @@ number:
     min_value: 1
     max_value: 999
     step: 1
-    initial_value: 5
+    initial_value: ${calibration_seconds_initial_value}
     update_interval: never
     restore_value: true
     optimistic: true
@@ -575,7 +583,7 @@ sensor:
     state_class: 'total_increasing'
     icon: 'mdi:counter'
     filters:
-      - delta: 1
+      - delta: ${half_rotations_update_delta}
 
   - platform: template
     id: ${prefix_id}sensor_total


### PR DESCRIPTION
Improvements from running this package on a slow gas meter (Sensus R-275, AMR magnet on the index drive shaft, 2.0 ft³ per rotation, ~140 s per rotation at typical residential flow).

### 1. Interval-based flow calculation
Flow was computed by counting half-rotations within a fixed window, so the smallest non-zero reading was one count per window — on slow meters flow flips between 0 and one quantized value. Flow is now derived from the measured interval between counts:

`volume_per_half_rotation × 60000 / max(last_interval_ms, elapsed_ms)`

Using `max()` lets the reading decay smoothly toward zero when flow stops instead of holding the last value. New substitution `flow_zero_timeout_seconds` (default 600 s) forces zero after prolonged inactivity.

### 2. `calibration_seconds_initial_value` substitution (gas default: 120 s)
The 5 s calibration default is a water-meter assumption. A gas meter rotation can take minutes, so 5 s captures a fragment of a swing and fits a magnet span far below reality. The water default stays 5 s; the gas package raises it to 120 s.

### 3. `half_rotations_update_delta` substitution
The Half rotations total sensor had a hardcoded `delta: 1`; since the delta filter passes only changes strictly greater than the threshold, the counter appears to advance in steps of 2. Exposing it (settable to 0) makes single increments visible during calibration.

### 4. README: drive-rate identification via proving dials
On AMR-equipped meters (e.g. Aclara STAR) the magnet often sits on the index drive shaft, where one rotation equals the meter's drive rate (1–2 ft³) rather than 0.125 ft³. Added guidance on reading the proving/test dials ("2 FT"/"1/2 FT" vs "1 FT"/"1/4 FT") to identify it.

### Testing
ESP8266 (D1 Mini) + QMC5883P, verified against dial-timed reference flow (2% agreement) and utility hourly consumption data over a billing cycle.